### PR TITLE
Added maskOffset property to extent the mask for large font sizes

### DIFF
--- a/FXLabel/FXLabel.h
+++ b/FXLabel/FXLabel.h
@@ -89,6 +89,7 @@
 @property (nonatomic) CGFloat lineSpacing;
 @property (nonatomic) CGFloat characterSpacing;
 @property (nonatomic) CGFloat baselineOffset;
+@property (nonatomic) CGFloat maskOffset;
 @property (nonatomic, copy) NSDictionary *kerningTable;
 @property (nonatomic) BOOL allowOrphans;
 

--- a/FXLabel/FXLabel.m
+++ b/FXLabel/FXLabel.m
@@ -742,6 +742,15 @@
     }
 }
 
+- (void)setMaskOffset:(CGFloat)maskOffset
+{
+    if (_maskOffset != maskOffset)
+    {
+        _maskOffset = maskOffset;
+        [self setNeedsDisplay];
+    }
+}
+
 - (void)setCharacterKerning:(NSDictionary *)kerningTable
 {
     if (_kerningTable != kerningTable)
@@ -919,7 +928,7 @@
     UIFont *font = [self.font fontWithSize:fontSize];
     
     //adjust for minimum height
-    textRect.size.height = MAX(textRect.size.height, font.lineHeight);
+    textRect.size.height = MAX(textRect.size.height, font.lineHeight) + _maskOffset;
     
     //set color
     UIColor *highlightedColor = self.highlightedTextColor ?: self.textColor;
@@ -984,7 +993,7 @@
     {
         //draw mask
         CGContextSaveGState(context);
-        [self FXLabel_drawTextInRect:textRect withFont:font];
+        [self FXLabel_drawTextInRect:CGRectOffset(textRect, 0, _maskOffset) withFont:font];
         CGContextRestoreGState(context);
         
         //create an image mask from what we've drawn so far


### PR DESCRIPTION
I have an FXLabel that the user can pinch to zoom and at large font sizes the mask is clipped at the top.

Ive added a maskOffset so that it can be extended when needed

![screen shot 2013-08-30 at 10 29 41 pm](https://f.cloud.github.com/assets/4196665/1056875/9a0b49ae-1162-11e3-8c7b-b1173a9e6773.png)

This is a great class btw!
